### PR TITLE
Debug black mask prediction display

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -53,23 +53,65 @@ def postprocess_mask(mask_logits: np.ndarray):
     # squeeze batch → (H, W)
     mask_indices = mask_indices[0]
     
-    # Normaliser les valeurs pour la visualisation
-    # Si on a N classes (0, 1, 2, ..., N-1), on les map sur [0, 255]
-    if mask_indices.max() > 0:
-        mask_normalized = (mask_indices / mask_indices.max() * 255).astype(np.uint8)
-    else:
-        mask_normalized = mask_indices.astype(np.uint8)
+    # Palette de couleurs optimisée pour 8 classes (0-7)
+    # Chaque classe aura une valeur bien distincte en niveaux de gris
+    color_map = np.array([
+        0,    # Classe 0: Noir (background généralement)
+        36,   # Classe 1: Gris très foncé
+        73,   # Classe 2: Gris foncé
+        109,  # Classe 3: Gris moyen-foncé
+        146,  # Classe 4: Gris moyen
+        182,  # Classe 5: Gris moyen-clair
+        219,  # Classe 6: Gris clair
+        255   # Classe 7: Blanc
+    ])
     
-    # Alternative: Couleurs distinctes pour chaque classe
-    # Décommentez les lignes suivantes si vous préférez des couleurs distinctes
-    # color_map = np.array([0, 85, 170, 255])  # 4 niveaux de gris bien espacés
-    # if mask_indices.max() < len(color_map):
-    #     mask_normalized = color_map[mask_indices]
-    # else:
-    #     mask_normalized = (mask_indices * 255 // mask_indices.max()).astype(np.uint8)
+    # Appliquer la palette de couleurs
+    if mask_indices.max() < len(color_map):
+        mask_normalized = color_map[mask_indices]
+    else:
+        # Fallback: normalisation linéaire si plus de 8 classes détectées
+        mask_normalized = (mask_indices / mask_indices.max() * 255).astype(np.uint8)
+    
+    # Convertir en uint8 si ce n'est pas déjà fait
+    mask_normalized = mask_normalized.astype(np.uint8)
     
     # ajout du canal → (H, W, 1)
     mask_normalized = mask_normalized[..., np.newaxis]
     # encode en PNG
     encoded = tf.io.encode_png(mask_normalized).numpy()
+    return encoded
+
+def postprocess_mask_color(mask_logits: np.ndarray):
+    """
+    Alternative en couleurs pour une meilleure visualisation des 8 classes.
+    mask_logits: np.ndarray shape (1, H, W, C)
+    Retourne les octets d'un PNG du mask (H, W, 3) en couleurs RGB.
+    """
+    # argmax → (1, H, W)
+    mask_indices = np.argmax(mask_logits, axis=-1)
+    # squeeze batch → (H, W)
+    mask_indices = mask_indices[0]
+    
+    # Palette de couleurs RGB distinctes pour 8 classes
+    color_palette = np.array([
+        [0, 0, 0],       # Classe 0: Noir (background)
+        [255, 0, 0],     # Classe 1: Rouge
+        [0, 255, 0],     # Classe 2: Vert
+        [0, 0, 255],     # Classe 3: Bleu
+        [255, 255, 0],   # Classe 4: Jaune
+        [255, 0, 255],   # Classe 5: Magenta
+        [0, 255, 255],   # Classe 6: Cyan
+        [255, 255, 255]  # Classe 7: Blanc
+    ], dtype=np.uint8)
+    
+    # Créer l'image couleur
+    h, w = mask_indices.shape
+    mask_color = np.zeros((h, w, 3), dtype=np.uint8)
+    
+    for class_id in range(min(len(color_palette), mask_indices.max() + 1)):
+        mask_color[mask_indices == class_id] = color_palette[class_id]
+    
+    # encode en PNG
+    encoded = tf.io.encode_png(mask_color).numpy()
     return encoded

--- a/front/main.py
+++ b/front/main.py
@@ -3,6 +3,7 @@ import io
 import requests
 import streamlit as st
 from PIL import Image
+import numpy as np
 
 # Config
 STREAMLIT_API_URL = os.getenv("STREAMLIT_API_URL", "http://localhost:8000").rstrip('/')
@@ -41,6 +42,13 @@ if uploaded_file is not None:
 
         # 4. Affichage du mask en niveaux de gris
         st.subheader("Mask prédit (classes par pixel)")
+        
+        # Informations de débogage
+        mask_array = np.array(mask_image)
+        st.write(f"Dimensions du masque: {mask_array.shape}")
+        st.write(f"Valeurs min/max du masque: {mask_array.min()}/{mask_array.max()}")
+        st.write(f"Valeurs uniques: {np.unique(mask_array)}")
+        
         st.image(mask_image, use_container_width=True, clamp=True, channels="L")
 
         # 5. (Optionnel) Superposition semi-transparente


### PR DESCRIPTION
Normalize mask pixel values in the API to ensure visibility and add debug information to the frontend.

The predicted masks appeared black because the pixel values, representing class indices (e.g., 0, 1, 2), were too low to be visible when directly displayed. This PR scales these values to the full 0-255 range, making the different classes visible as varying shades of gray. Debug information was also added to the frontend to help verify the pixel values.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf83f13c-a93e-47f7-85f3-5f6bc85f3105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf83f13c-a93e-47f7-85f3-5f6bc85f3105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>