### PR TITLE
Ajuster les couleurs selon le mapping

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -93,16 +93,16 @@ def postprocess_mask_color(mask_logits: np.ndarray):
     # squeeze batch → (H, W)
     mask_indices = mask_indices[0]
     
-    # Palette de couleurs RGB distinctes pour 8 classes
+    # Palette de couleurs RGB correspondant au GROUP_PALETTE du notebook
     color_palette = np.array([
-        [0, 0, 0],       # Classe 0: Noir (background)
-        [255, 0, 0],     # Classe 1: Rouge
-        [0, 255, 0],     # Classe 2: Vert
-        [0, 0, 255],     # Classe 3: Bleu
-        [255, 255, 0],   # Classe 4: Jaune
-        [255, 0, 255],   # Classe 5: Magenta
-        [0, 255, 255],   # Classe 6: Cyan
-        [255, 255, 255]  # Classe 7: Blanc
+        [128, 64, 128],   # Classe 0: flat (route, trottoir, etc.) - Violet-gris
+        [220, 20, 60],    # Classe 1: human (personne, cycliste) - Rouge-crimson
+        [0, 0, 142],      # Classe 2: vehicle (voiture, camion, etc.) - Bleu foncé
+        [70, 70, 70],     # Classe 3: construction (bâtiment, mur, etc.) - Gris foncé
+        [220, 220, 0],    # Classe 4: object (poteau, panneau, etc.) - Jaune
+        [107, 142, 35],   # Classe 5: nature (végétation, terrain) - Vert olive
+        [70, 130, 180],   # Classe 6: sky (ciel) - Bleu ciel
+        [0, 0, 0]         # Classe 7: void (non labellisé, hors ROI) - Noir
     ], dtype=np.uint8)
     
     # Créer l'image couleur

--- a/front/main.py
+++ b/front/main.py
@@ -71,17 +71,17 @@ if uploaded_file is not None:
                 st.write(f"🎨 Mode: Couleurs RGB")
                 st.write(f"🖼️ Classes détectées: {len(np.unique(mask_array.flatten())) if len(mask_array.shape) == 3 else len(unique_values)}")
                 
-                # Légende des couleurs pour le mode couleur
+                # Légende des couleurs pour le mode couleur (correspondant au GROUP_PALETTE du notebook)
                 st.write("**Légende des couleurs:**")
                 color_legend = [
-                    "🖤 Classe 0: Noir (background)",
-                    "🔴 Classe 1: Rouge", 
-                    "🟢 Classe 2: Vert",
-                    "🔵 Classe 3: Bleu",
-                    "🟡 Classe 4: Jaune",
-                    "🟣 Classe 5: Magenta",
-                    "🩵 Classe 6: Cyan",
-                    "⚪ Classe 7: Blanc"
+                    "🟣 Classe 0: Flat (route, trottoir) - Violet-gris",
+                    "🔴 Classe 1: Human (personne, cycliste) - Rouge-crimson", 
+                    "🔵 Classe 2: Vehicle (voiture, camion) - Bleu foncé",
+                    "⚫ Classe 3: Construction (bâtiment, mur) - Gris foncé",
+                    "🟡 Classe 4: Object (poteau, panneau) - Jaune",
+                    "🟢 Classe 5: Nature (végétation, terrain) - Vert olive",
+                    "🩵 Classe 6: Sky (ciel) - Bleu ciel",
+                    "🖤 Classe 7: Void (non labellisé, hors ROI) - Noir"
                 ]
                 for legend in color_legend:
                     st.write(f"• {legend}")


### PR DESCRIPTION
Adjust colors in API and frontend to match the `GROUP_PALETTE` defined in the notebook.

---
<a href="https://cursor.com/background-agent?bcId=bc-9803c9ce-b819-4926-b8be-fca4c6c61484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9803c9ce-b819-4926-b8be-fca4c6c61484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>